### PR TITLE
Increase max number of packets in cache and duration to keep packets

### DIFF
--- a/src/main/java/org/jitsi/videobridge/transform/CachingTransformer.java
+++ b/src/main/java/org/jitsi/videobridge/transform/CachingTransformer.java
@@ -42,7 +42,7 @@ public class CachingTransformer
      * Packets added to the cache more than <tt>SIZE_MILLIS</tt> ago might be
      * cleared from the cache.
      */
-    private static int SIZE_MILLIS = 300;
+    private static int SIZE_MILLIS = 10000;
 
     /**
      * Assumed rate of the RTP clock.
@@ -63,7 +63,7 @@ public class CachingTransformer
     /**
      * The maximum number of packets cached for each SSRC.
      */
-    private static int MAX_SIZE_PACKETS = 200;
+    private static int MAX_SIZE_PACKETS = 3000;
 
     /**
      * The size of {@link #pool}.


### PR DESCRIPTION
Should increase performance by limiting the number of necessary retransmissions 
