### PR TITLE
Fixes bug when active speaker and pinned accomplice are the same

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /junit-reports/
 *.swp
 /target/
+.idea/

--- a/src/main/java/org/jitsi/videobridge/VideoChannel.java
+++ b/src/main/java/org/jitsi/videobridge/VideoChannel.java
@@ -614,20 +614,26 @@ public class VideoChannel
                 // The pinned endpoint is always in the last N set, if
                 // last N > 0.
                 Endpoint pinnedEndpoint = getEffectivePinnedEndpoint();
+                boolean pinned = pinnedEndpoint != null;
+
                 // Keep one empty slot for the pinned endpoint.
-                int nMax = (pinnedEndpoint == null) ? lastN : (lastN - 1);
+                int nMax = (pinned) ? lastN - 1 : lastN;
+
+                if (pinned)
+                    inLastN = channelEndpoint == pinnedEndpoint;
+
                 Endpoint thisEndpoint = getEndpoint();
 
                 for (WeakReference<Endpoint> wr : lastNEndpoints)
                 {
-                    if (n >= nMax)
+                    if (n >= nMax || inLastN)
                         break;
 
                     Endpoint e = wr.get();
 
                     if (e != null)
                     {
-                        if (e.equals(thisEndpoint))
+                        if (e.equals(thisEndpoint) || (pinned && e.equals(pinnedEndpoint)))
                         {
                             continue;
                         }
@@ -640,11 +646,6 @@ public class VideoChannel
 
                     ++n;
                 }
-
-                // FIXME(gp) move this if before the for loop (to avoid an
-                // unnecessary loop)
-                if (!inLastN && pinnedEndpoint != null)
-                    inLastN = channelEndpoint == pinnedEndpoint;
             }
         }
         finally


### PR DESCRIPTION
Fixes issue where if pinned user and active speaker are the same, this causes the client to download lastN-1 streams

The code was effectively counting the pinnedEndpoint twice as it was first in the lastNEndpoints list (which is the ordered list of active speakers)
